### PR TITLE
MissingMandatoryParametersException when a view has route parameters other than %node

### DIFF
--- a/src/IslandoraBreadcrumbBuilder.php
+++ b/src/IslandoraBreadcrumbBuilder.php
@@ -125,7 +125,7 @@ class IslandoraBreadcrumbBuilder implements BreadcrumbBuilderInterface {
         $breadcrumb->addLink(Link::createFromRoute($this->t("Collections"), '<none>'));
       }else {
         $this->setReferenceBreadcrumbs($breadcrumb, $node);
-        $breadcrumb->addLink(Link::createFromRoute($title, $route_name, ['node' => $nid]));
+        $breadcrumb->addLink(Link::createFromRoute($title, $route_name, $parameters));
       }
     }else{
       global $isIslandora;


### PR DESCRIPTION
**To reproduce:**
- log in as admin
- go to `/admin/content/files`
- click any entry under the `Used in` column (this redirects to `/file/%file/usage`)
- the site displays `The website encountered an unexpected error. Please try again later.`

**From drupal log:**
```
Symfony\Component\Routing\Exception\MissingMandatoryParametersException: 
Some mandatory parameters are missing ("file") to generate a URL for route 
"view.file_entity_files.usage". in Drupal\Core\Routing\UrlGenerator->doGenerate() 
(line 181 of /var/www/drupal/web/core/lib/Drupal/Core/Routing/UrlGenerator.php).
```

**Cause:** When the link is being created for the breadcrumbs, if the path contains a number, it always passes it as a %node parameter.

In src/IslandoraBreadcrumbBuilder.php line 128:
`$breadcrumb->addLink(Link::createFromRoute($title, $route_name, ['node' => $nid]));`

**Solution:** Pass all route parameters when creating a link from a route.