### PR TITLE
remove collection page special link

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+  "name": "islandora_lite/islandora_breadcrumbs",
+  "type": "drupal-module",
+  "description": "Breadcrumbs for Islandora objects",
+  "keywords": ["Drupal"]
+}

--- a/src/IslandoraBreadcrumbBuilder.php
+++ b/src/IslandoraBreadcrumbBuilder.php
@@ -252,17 +252,7 @@ class IslandoraBreadcrumbBuilder implements BreadcrumbBuilderInterface {
    */
   protected function getViewLink(Node $node) {
     $nid = $node->id();
-    if (Term::load($node->get('field_model')->target_id)->get('name')->value === "Collection") {
-      $url_object = \Drupal::service('path.validator')->getUrlIfValid("/collection/%node");
-      if ($url_object == FALSE)
-        return $node->toLink();
-      else
-        $route_name = $url_object->getRouteName();
-      /* If the parent is collection,
-      replace the node link with collection view link. */
-      return Link::createFromRoute($node->getTitle(), $route_name, ['node' => $nid]);
-    }
-    elseif (Term::load($node->get('field_model')->target_id)->get('name')->value === "Paged Content") {
+    if (Term::load($node->get('field_model')->target_id)->get('name')->value === "Paged Content") {
       return Link::createFromRoute($node->getTitle(), "entity.node.canonical", ['node' => $node->id()]);
     }
     else {


### PR DESCRIPTION
Originally, we had view page driven collection views.  If the user navigates to an item from a collection, then we redirected to "colleciton/#".  This is no longer needed, as we moved to a block based views, and can make use of collection node itself.  

Also, added a composer file.  